### PR TITLE
[README] Fix using action-textlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
       - name: run textlint
         id: run-textlint
         run: |
-          echo "::set-output name=TEXTLINT_OUTPUT::$(./node_modules/.bin/textlint 'docs/**/*.md' -f json)"
+          echo "TEXTLINT_OUTPUT=$(./node_modules/.bin/textlint 'docs/**/*.md' -f json)" >> $GITHUB_OUTPUT
       - uses: yutailang0119/action-textlint@v3
         with:
           textlint-output: ${{ steps.run-textlint.outputs.TEXTLINT_OUTPUT }}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
       - name: run textlint
         id: run-textlint
         run: |
-          echo "TEXTLINT_OUTPUT=$(./node_modules/.bin/textlint 'docs/**/*.md' -f json)" >> $GITHUB_OUTPUT
+          echo "TEXTLINT_OUTPUT=$(./node_modules/.bin/textlint 'docs/**/*.md' -f json || true)" >> $GITHUB_OUTPUT
       - uses: yutailang0119/action-textlint@v3
         with:
           textlint-output: ${{ steps.run-textlint.outputs.TEXTLINT_OUTPUT }}


### PR DESCRIPTION
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/